### PR TITLE
Replaced kwargs by named args for train_test_split

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2072,7 +2072,12 @@ def check_cv(cv=5, y=None, *, classifier=False):
     return cv  # New style cv objects are passed without any modification
 
 
-def train_test_split(*arrays, **options):
+def train_test_split(*arrays,
+                     test_size=None,
+                     train_size=None,
+                     random_state=None,
+                     shuffle=True,
+                     stratify=None):
     """Split arrays or matrices into random train and test subsets
 
     Quick utility that wraps input validation and


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
By using **options in the argument list, named arguments where not immediately shown when pressing shift+tab in jupyter. I replaced it by using named arguments and their default values described in the docstring.
